### PR TITLE
Change the implementation of is_numeric()

### DIFF
--- a/R/base.R
+++ b/R/base.R
@@ -3,15 +3,17 @@
 #' A more general test of an object being interpretable as numbers.
 #'
 #' @param x	Character vector of values to parse.
-#' @param na	Character vector of strings to use for missing values.
-#'   Set this option to \code{character()} to indicate no missing values.
+#' @param na	Boolean. It determines wether NA is regarded as TRUE/FALSE.
 #'
 #' @examples
 #' x <- c(1, 2, NA, "AAA", "123")
 #' is_numeric(x)
 #'
 #' @export
-is_numeric <- function(x, na = c("", "NA"))
+is_numeric <- function(x, na = FALSE)
 {
-  suppressWarnings(!is.na(readr::parse_number(x, na=na)))
+  result <- rep(na, length(x))
+  index_na <- is.na(x)
+  result[!index_na] <- suppressWarnings(!is.na(as.numeric(x[!index_na])))
+  result
 }

--- a/man/is_numeric.Rd
+++ b/man/is_numeric.Rd
@@ -4,13 +4,12 @@
 \alias{is_numeric}
 \title{A more general test of an object being interpretable as numbers.}
 \usage{
-is_numeric(x, na = c("", "NA"))
+is_numeric(x, na = FALSE)
 }
 \arguments{
 \item{x}{Character vector of values to parse.}
 
-\item{na}{Character vector of strings to use for missing values.
-Set this option to \code{character()} to indicate no missing values.}
+\item{na}{Boolean. It determines wether NA is regarded as TRUE/FALSE.}
 }
 \description{
 A more general test of an object being interpretable as numbers.

--- a/tests/testthat/test-base.R
+++ b/tests/testthat/test-base.R
@@ -3,10 +3,12 @@ context("base.R")
 test_that("is_numeric() for vector", {
   x <- c(1, 2, NA, "AAA", "123")
   expect_equal(is_numeric(x), c(TRUE, TRUE, FALSE, FALSE, TRUE))
+  expect_equal(is_numeric(x, na=TRUE),  c(TRUE, TRUE, TRUE, FALSE, TRUE))
+  expect_equal(is_numeric(x, na=FALSE), c(TRUE, TRUE, FALSE, FALSE, TRUE))
 })
 
 test_that("is_numeric() for data.frame", {
   df <- dplyr::data_frame(a=c(NA, "A", "", "123", "432"))
   expect_equal(dplyr::filter(df, is_numeric(a)), dplyr::tibble(a=c("123", "432")))
-  expect_equal(dplyr::filter(df, is_numeric(a, na="123")), dplyr::tibble(a="432"))
+  expect_equal(dplyr::filter(df, is_numeric(a, na=TRUE)), dplyr::tibble(a=c(NA, "123", "432")))
 })


### PR DESCRIPTION
Change the implementation of `is_numeric()`.

Because `readr::parse_number()` can parse the string like "hoge 232 mogemoge".
It should not be regarded as number in our case...